### PR TITLE
Refactor: 장르 관리 방식을 Enum으로 개선하여 타입 안정성 확보 (#39)

### DIFF
--- a/src/main/java/com/spring/aidea/vibefiction/dto/request/novel/NovelCreateRequestTj.java
+++ b/src/main/java/com/spring/aidea/vibefiction/dto/request/novel/NovelCreateRequestTj.java
@@ -1,24 +1,25 @@
 package com.spring.aidea.vibefiction.dto.request.novel;
 
 import com.spring.aidea.vibefiction.entity.Novels.NovelVisibility;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+
+import java.util.List;
 
 /**
  * 새로운 소설 작품을 생성하기 위해 사용되는 데이터 전송 객체(DTO)입니다.
  *
- * 이 객체는 소설의 기본 정보(제목, 시놉시스, 장르 등)와 함께 첫 번째 회차(1화)의
+ * <p>이 객체는 소설의 기본 정보(제목, 시놉시스, 장르 등)와 함께 첫 번째 회차(1화)의
  * 제목과 내용을 담아, 소설과 1화를 한 번의 요청으로 동시에 생성하는 기능을 지원합니다.
  *
  * @author 왕택준
  * @since 2025.08
  */
 @Getter
-//@Setter // [보안/설계] 불변성을 위해 Setter는 비활성화. 생성 시에만 값이 할당되도록 Builder 패턴 사용을 권장.
+//@Setter // [보안/설계] 불변성을 위해 Setter는 비활성화.
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -30,16 +31,18 @@ public class NovelCreateRequestTj {
      * <b>[비즈니스 규칙]</b> 소설을 식별하는 가장 중요한 정보이며, 비어 있을 수 없습니다.
      * 최대 50자까지 입력 가능합니다.
      */
-    @NotBlank(message = "소설 제목은 비어 있을 수 없습니다.")
+    @NotBlank(message = "소설 제목은 비워 있을 수 없습니다.")
     @Size(max = 50, message = "소설 제목은 50자를 초과할 수 없습니다.")
     private String title;
 
     /**
-     * 소설의 전체 줄거리를 요약한 시놉시스입니다. (선택 사항)
+     * [리팩토링] 사용자가 구상하고 있는 소설의 핵심 아이디어나 줄거리입니다. (필수 입력)
      * <p>
-     * <b>[비즈니스 규칙]</b> 독자들이 소설을 읽기 전 작품의 내용을 파악하는 데 도움을 줍니다.
+     * <b>[비즈니스 규칙]</b> 독자들이 소설을 선택하기 전 작품의 대략적인 내용을 파악하는 데 도움을 주며,
+     * AI 보조 기능 사용 시 더 정확한 추천을 생성하는 기반 데이터로 활용됩니다.
      * 최대 2000자까지 입력 가능합니다.
      */
+    @NotBlank(message = "시놉시스는 비워둘 수 없습니다.")
     @Size(max = 2000, message = "시놉시스는 2000자를 초과할 수 없습니다.")
     private String synopsis;
 
@@ -49,7 +52,7 @@ public class NovelCreateRequestTj {
      * <b>[비즈니스 규칙]</b> 소설 생성 시 1화를 함께 등록하는 편의 기능을 위해 사용됩니다.
      * 비어 있을 수 없습니다.
      */
-    @NotBlank(message = "1화 제목은 비어 있을 수 없습니다.")
+    @NotBlank(message = "1화 제목은 비워 있을 수 없습니다.")
     @Size(max = 60, message = "1화 제목은 60자를 초과할 수 없습니다.")
     private String firstChapterTitle;
 
@@ -59,20 +62,36 @@ public class NovelCreateRequestTj {
      * <b>[비즈니스 규칙]</b> 소설의 시작을 알리는 내용으로, 비어 있을 수 없습니다.
      * 최대 5000자까지 입력 가능합니다.
      */
-    @NotBlank(message = "1화 내용은 비어 있을 수 없습니다.")
+    @NotBlank(message = "1화 내용은 비워 있을 수 없습니다.")
     @Size(max = 5000, message = "1화 내용은 5000자를 초과할 수 없습니다.")
     private String firstChapterContent;
 
+    /*
+     * [리팩토링-AS-IS] 기존 장르 입력 방식 (DB의 genre_id 기반)
+     * @author 왕택준
+     *
+     * [주석 처리 이유]
+     * Genres 엔티티의 name 필드가 GenreType Enum으로 변경됨에 따라, 클라이언트와의 통신 방식도
+     * DB의 PK(ID)가 아닌, Enum의 상수명(e.g., "FANTASY")을 문자열로 직접 주고받도록 수정합니다.
+     * 이는 클라이언트가 장르 ID를 미리 알 필요 없이, 약속된 문자열만으로 통신할 수 있게 하여
+     * 시스템 간의 결합도를 낮추는 효과가 있습니다.
+     *
+    @NotEmpty(message = "장르는 최소 1개 이상 선택해야 합니다.")
+    private List<Integer> genreIds;
+    */
+
     /**
-     * 소설에 적용할 장르의 고유 ID 목록입니다.
+     * [리팩토링-TO-BE] 소설에 적용할 장르의 이름(Enum 상수명) 목록입니다.
+     * <p>
+     * <b>[전송 예시]</b>: {@code ["FANTASY", "ROMANCE"]}
      * <p>
      * <b>[비즈니스 규칙]</b> 소설의 카테고리 분류 및 검색에 사용되며,
      * 최소 1개 이상의 장르를 필수로 선택해야 합니다.
      *
-     * @see com.spring.aidea.vibefiction.entity.Genres.Genre
+     * @see com.spring.aidea.vibefiction.entity.Genres.GenreType
      */
     @NotEmpty(message = "장르는 최소 1개 이상 선택해야 합니다.")
-    private List<Integer> genreIds;
+    private List<String> genres;
 
     /**
      * 소설의 공개 범위 설정 값입니다. (PUBLIC, PRIVATE, FRIENDS 중 하나)

--- a/src/main/java/com/spring/aidea/vibefiction/dto/response/novel/NovelsResponseDtoSH.java
+++ b/src/main/java/com/spring/aidea/vibefiction/dto/response/novel/NovelsResponseDtoSH.java
@@ -1,10 +1,21 @@
 package com.spring.aidea.vibefiction.dto.response.novel;
-import com.spring.aidea.vibefiction.entity.*;
+
+import com.spring.aidea.vibefiction.entity.Genres;
+import com.spring.aidea.vibefiction.entity.NovelGenres;
+import com.spring.aidea.vibefiction.entity.Novels;
 import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
+/**
+ * 소설 목록 또는 상세 정보 조회 시 사용될 데이터 전송 객체(DTO)입니다.
+ *
+ * @author SH (Original Author)
+ * @author 왕택준 (Refactored by)
+ * @since 2025.08
+ */
 @Getter
 @ToString
 @EqualsAndHashCode
@@ -13,19 +24,55 @@ import java.util.List;
 @Builder
 public class NovelsResponseDtoSH {
 
-    Long novelId; // 소설 ID
-    String title; // 소설 제목
-    String author; // 소설 작성자
-    String authorName;
-    String coverImageUrl; // 소설 썸네일 이미지 경로
-    String synopsis; // 소설 시놉시스(줄거리)
-    String status; // 공개 상태
-    Long viewCount; // 조회수
-    List<String> novelGenres; // 소설 분류
-    LocalDateTime laseUpdatedAt; // 최종 수정일시
+    /** 소설의 고유 식별자(ID) */
+    private Long novelId;
 
+    /** 소설의 제목 */
+    private String title;
+
+    /** 소설 원작자의 고유 식별자(ID) */
+    private Long authorId;
+
+    /** 소설 원작자의 닉네임 */
+    private String authorName;
+
+    /** 소설 표지 이미지의 URL */
+    private String coverImageUrl;
+
+    /** 소설의 시놉시스 (줄거리 요약) */
+    private String synopsis;
+
+    /** 소설의 현재 연재 상태 (e.g., "ONGOING", "COMPLETED") */
+    private String status;
+
+    /** 소설의 총 조회수 */
+    private Long viewCount;
+
+    /** 소설에 부여된 장르 목록 (Enum 상수명, e.g., "FANTASY", "ROMANCE") */
+    private List<String> genres;
+
+    /** 소설이 마지막으로 업데이트된 일시 */
+    private LocalDateTime lastUpdatedAt;
+
+
+    /**
+     * Novels 엔티티를 클라이언트에 전달할 DTO 형태로 변환하는 정적 팩토리 메서드입니다.
+     *
+     * @param novels 변환할 원본 Novels 엔티티 객체
+     * @return 변환된 NovelsResponseDtoSH 객체
+     */
     public static NovelsResponseDtoSH from(Novels novels) {
 
+        /*
+         * [리팩토링-AS-IS] 기존 변환 로직 (Original Author: SH)
+         * @author 왕택준 (Refactored by)
+         *
+         * [주석 처리 이유]
+         * Genres 엔티티의 name 필드가 String에서 Genres.GenreType Enum으로 변경되었습니다.
+         * 따라서 .map(Genres::getName)을 호출할 때 반환 타입이 Enum으로 바뀌었으므로,
+         * 이를 클라이언트에게 보낼 문자열로 변환하기 위해 .map(type -> type.name()) 또는
+         * .map(Genres.GenreType::name)을 호출하는 로직으로 수정합니다.
+         *
         return NovelsResponseDtoSH.builder()
                 .novelId(novels.getNovelId())
                 .title(novels.getTitle())
@@ -41,13 +88,28 @@ public class NovelsResponseDtoSH {
                         .map(Genres::getName)
                         .toList()
                 )
-
                 .laseUpdatedAt(novels.getLastUpdatedAt())
-
                 .build();
+        */
 
-
+        // [리팩토링-TO-BE] 새로운 변환 로직
+        return NovelsResponseDtoSH.builder()
+            .novelId(novels.getNovelId())
+            .title(novels.getTitle())
+            .authorId(novels.getAuthor().getUserId())
+            .authorName(novels.getAuthor().getNickname())
+            .coverImageUrl(novels.getCoverImageUrl())
+            .synopsis(novels.getSynopsis())
+            .status(novels.getStatus().name())
+            .viewCount(novels.getViewCount())
+            .genres(novels.getNovelGenres()
+                .stream()
+                .map(NovelGenres::getGenre)
+                .map(Genres::getName)
+                .map(Genres.GenreType::name)
+                .collect(Collectors.toList())
+            )
+            .lastUpdatedAt(novels.getLastUpdatedAt())
+            .build();
     }
-
-
 }

--- a/src/main/java/com/spring/aidea/vibefiction/entity/Genres.java
+++ b/src/main/java/com/spring/aidea/vibefiction/entity/Genres.java
@@ -7,6 +7,17 @@ import org.hibernate.annotations.Comment;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * 소설의 장르 마스터 정보를 관리하는 엔티티 클래스입니다.
+ * <p>
+ * [리팩토링]
+ * 장르의 이름을 나타내는 {@code name} 필드가 기존의 {@code String} 타입에서
+ * 내부적으로 정의된 {@link GenreType} Enum 타입으로 변경되었습니다.
+ * 이는 장르 데이터의 정합성과 타입 안정성을 코드 레벨에서 보장하기 위함입니다.
+ *
+ * @author 왕택준
+ * @since 2025.08
+ */
 @Entity
 @Table(name = "genres")
 @Getter
@@ -18,19 +29,88 @@ import java.util.List;
 @Comment("장르 마스터 테이블")
 public class Genres {
 
+    /**
+     * 플랫폼에서 사용될 소설 장르의 종류를 정의하는 열거형(Enum)입니다.
+     * <p>
+     * 각 Enum 상수는 데이터베이스의 {@code name} 컬럼에 문자열로 저장되며({@code FANTASY}, {@code ROMANCE} 등),
+     * 사용자에게 보여줄 한글 설명({@code description})을 함께 가집니다.
+     * 이 Enum은 {@code Genres} 엔티티 내부에서만 사용되어 높은 응집도를 유지합니다.
+     */
+    @Getter
+    @RequiredArgsConstructor
+    public enum GenreType {
+        // --- 대중적인 메인 장르 ---
+        FANTASY("판타지"),
+        ROMANCE("로맨스"),
+        MODERN_FANTASY("현대판타지"),
+        MARTIAL_ARTS("무협"),
+        MYSTERY("미스터리"),
+        HORROR("호러"),
+        SCI_FI("SF"),
+        THRILLER("스릴러"),
+        ACTION("액션"),
+        COMEDY("코미디"),
+        DRAMA("드라마"),
+        HISTORICAL("시대극/역사"),
+
+        // --- 웹소설 인기 하위 장르/설정 ---
+        ROMANCE_FANTASY("로맨스판타지"),
+        GAME_FANTASY("게임판타지"),
+        REGRESSION("회귀"),
+        REINCARNATION("빙의/환생"),
+        ACADEMY("아카데미"),
+        APOCALYPSE("아포칼립스"),
+
+        // --- 팬덤/특정 취향 장르 ---
+        BL("BL"),
+        GL("GL"),
+
+        // --- 기타 ---
+        SLICE_OF_LIFE("일상"),
+        SHORT_STORY("단편");
+
+        private final String description;
+    }
+
+    /**
+     * 장르의 고유 식별자(Primary Key)입니다. 데이터베이스에 의해 자동으로 생성됩니다.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "genre_id", columnDefinition = "INT")
     @Comment("장르 ID")
     private Integer genreId;
 
+    /**
+     * [리팩토링-TO-BE] GenreType Enum 필드
+     * <p>
+     * {@link GenreType} Enum을 사용하여 장르의 종류를 코드 레벨에서 강제합니다.
+     * {@code @Enumerated(EnumType.STRING)} 설정을 통해, 데이터베이스의 'name' 컬럼에는
+     * Enum의 상수명(e.g., "FANTASY")이 문자열로 저장됩니다.
+     */
+    @Enumerated(EnumType.STRING)
     @Column(name = "name", length = 50, nullable = false, unique = true)
     @Comment("장르 이름")
-    private String name;
+    private GenreType name;
 
-    // --- 연관관계 ---
+    /**
+     * 이 장르를 가지고 있는 소설들과의 연결 관계(N:M)를 나타내는 필드입니다.
+     * {@link NovelGenres} 연결 엔티티를 통해 관리됩니다.
+     */
     @OneToMany(mappedBy = "genre", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<NovelGenres> novelGenres = new ArrayList<>();
 
+    /*
+     * [리팩토링-AS-IS] 기존 String 타입 name 필드
+     *
+     * @author 왕택준
+     * 장르 이름을 자유로운 문자열로 저장하는 기존 방식은 데이터의 오타나 비일관성을 막을 수 없습니다.
+     * 이를 해결하기 위해, 이 클래스 내부에 사전 정의된 GenreType Enum을 사용하여
+     * 데이터의 정합성과 타입 안정성을 확보하는 방식으로 필드 타입을 변경했습니다.
+     *
+    @Column(name = "name", length = 50, nullable = false, unique = true)
+    @Comment("장르 이름")
+    private String name;
+    */
 }

--- a/src/main/java/com/spring/aidea/vibefiction/repository/GenresRepository.java
+++ b/src/main/java/com/spring/aidea/vibefiction/repository/GenresRepository.java
@@ -3,8 +3,19 @@ package com.spring.aidea.vibefiction.repository;
 import com.spring.aidea.vibefiction.entity.Genres;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface GenresRepository extends JpaRepository<Genres, Integer> {
+
+    /**
+     * [리팩토링] GenreType Enum 목록에 해당하는 Genres 엔티티 목록을 조회합니다.
+     * Spring Data JPA의 'In' 키워드를 사용하여, 'WHERE name IN (?, ?, ...)' 쿼리를 자동으로 생성합니다.
+     *
+     * @param names 조회할 장르의 GenreType Enum 목록
+     * @return 조회된 Genres 엔티티 목록
+     *
+     * @author 왕택준
+     */
+    List<Genres> findByNameIn(List<Genres.GenreType> names);
 
 }


### PR DESCRIPTION
## PR 유형 (Type of PR)

*   [ ] 기능 (Feature)
*   [x] 리팩토링 (Refactoring)

---

## PR 요약 (PR Summary)

`Genres` 엔티티의 `name` 필드를 기존의 `String` 타입에서 `Genres.GenreType` Enum 타입으로 변경하여, 장르 데이터의 정합성과 타입 안정성을 코드 레벨에서 보장하도록 리팩토링했습니다. 이와 함께 클라이언트와의 통신 방식(DTO), 서비스 로직, Repository 쿼리 등 장르와 관련된 모든 부분을 일관성 있게 수정하여 시스템의 안정성을 향상시켰습니다.

---

## 관련 이슈 (Related Issue)

*   Closes #39 

---

## 변경 사항 (Changes)

1.  **`Genres` 엔티티 수정**: `name` 필드의 타입을 `String`에서 `Genres.GenreType` Enum으로 변경하고, `@Enumerated(EnumType.STRING)`을 적용했습니다.
2.  **`NovelCreateRequestTj` (DTO) 수정**: 장르 입력 필드를 `List<Integer> genreIds`에서 `List<String> genres`로 변경했습니다.
3.  **`GenresRepository` 수정**: Enum 목록으로 `Genres` 엔티티를 조회하는 `findByNameIn(...)` 메서드를 추가했습니다.
4.  **`NovelServiceTj` 로직 수정**: DTO로 받은 장르 이름(String)을 Enum으로 변환하고, 새로운 Repository 메서드를 사용하여 `Genres`를 조회하도록 로직을 수정했습니다.
5.  **`NovelsResponseDtoSH` (조회 DTO) 수정**: `Genres.GenreType` Enum을 다시 `String`으로 변환하여 클라이언트에 반환하도록 로직을 수정했습니다.

---

## 테스트 방법 (Test Steps)

> **⚠️ 중요: 리뷰어를 위한 DB 테스트 환경 준비**
>
> 이번 리팩토링으로 `genres` 테이블의 스키마와 데이터 규칙이 변경되었습니다. 원활한 테스트를 위해, 아래 SQL 스크립트를 실행하여 로컬 데이터베이스를 최신 상태로 초기화해주세요.

### 1. DB 초기화 및 데이터 재입력

1.  **DB 관리 도구에서 아래 쿼리를 순서대로 실행합니다.**

    ```sql
    -- 모든 테스트 데이터를 지우고 처음부터 시작합니다.
    -- 순서가 중요합니다! (외래 키 제약조건)
    DELETE FROM novel_genres;
    DELETE FROM chapters;
    DELETE FROM proposals;
    DELETE FROM novels;
    DELETE FROM users;
    DELETE FROM genres;
    
    ALTER TABLE users AUTO_INCREMENT = 1;
    ALTER TABLE novels AUTO_INCREMENT = 1;
    ALTER TABLE chapters AUTO_INCREMENT = 1;
    ALTER TABLE proposals AUTO_INCREMENT = 1;
    ALTER TABLE genres AUTO_INCREMENT = 1;
    ```

2.  **필수 장르 데이터를 다시 입력합니다.**

    ```sql
    -- Enum과 100% 일치하는 올바른 장르 데이터만 다시 추가합니다.
    INSERT INTO genres (name) VALUES
    ('FANTASY'), ('ROMANCE'), ('MODERN_FANTASY'), ('MARTIAL_ARTS'),
    ('MYSTERY'), ('HORROR'), ('SCI_FI'), ('THRILLER'), ('ACTION'),
    ('COMEDY'), ('DRAMA'), ('HISTORICAL'), ('ROMANCE_FANTASY'),
    ('GAME_FANTASY'), ('REGRESSION'), ('REINCARNATION'), ('ACADEMY'),
    ('APOCALYPSE'), ('BL'), ('GL'), ('SLICE_OF_LIFE'), ('SHORT_STORY');
    ```

3.  **애플리케이션을 재시작합니다.**

### 2. API 테스트 (Postman 전체 시나리오)

> **테스트 팁**: 2단계(로그인)에서 발급받은 `accessToken` 값을 복사해두었다가, 이후 인증이 필요한 모든 요청의 `Authorization` 헤더에 `Bearer ` 접두사와 함께 붙여넣어 사용하세요.

| 단계 | 기능 | Method | URL | Body (Raw/JSON) | 주요 확인 사항 |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **1** | **회원가입** | `POST` | `http://localhost:9009/api/auth/signup` | `{ "loginId": "testuser", "password": "password123!", "nickname": "테스터", "email": "test@test.com", "birthDate": "2000-01-01" }` | `200 OK` 응답 확인.<br>DB `users` 테이블에 ID `1`번으로 데이터 생성 확인. |
| **2** | **로그인** | `POST` | `http://localhost:9009/api/auth/login` | `{ "loginIdOrEmail": "testuser", "password": "password123!"}` | `200 OK` 응답과 `accessToken` 발급 확인. (토큰 복사) |
| **3** | **새 소설 생성** | `POST` | `http://localhost:9009/api/novels` | `{ "title": "...", "synopsis": "...", "firstChapterTitle": "...", "firstChapterContent": "...", "genres": ["FANTASY", "ACTION"], "visibility": "PUBLIC" }` | **`201 Created`** 응답과 `novelId: 1`, `firstChapterId: 1` 반환 확인. |
| **4** | **이어쓰기 제안** | `POST` | `http://localhost:9009/api/chapters/1/proposals` | `{ "title": "2화 제안", "content": "주인공이 사실..."}` | **`201 Created`** 응답과 `proposalId: 1` 반환 확인.<br>리팩토링이 이어쓰기 기능에 영향을 주지 않았는지 검증. |
| **5** | **(실패 테스트)** | `POST` | `http://localhost:9009/api/novels` | `{ ..., "genres": ["FANTASY", "INVALID_GENRE"], ... }` | `400 Bad Request` 응답과 `"유효하지 않은 장르가 포함되어 있습니다."` 메시지 확인. |

---

## 셀프 체크리스트 (Self-Checklist)

*   [x] 제목 규칙을 지켰습니다.
*   [x] 관련 이슈를 연결했습니다.
*   [x] 로컬에서 DB 초기화 후 Postman E2E 테스트(회원가입~이어쓰기)를 성공적으로 완료했습니다.
*   [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.

---

## 리뷰어에게 (To Reviewers)

*   이번 리팩토링의 핵심은 `Genres` 엔티티의 `name` 필드를 `Enum`으로 변경하여 타입 안정성을 확보한 것입니다.
*   **테스트를 진행하시기 전에, 반드시 `테스트 방법` 섹션의 DB 초기화 및 데이터 재입력 스크립트를 실행해주셔야 합니다.**
*   `NovelServiceTj`에서 클라이언트로부터 받은 `List<String>`을 `List<Genres.GenreType>`으로 변환하고, 이를 다시 DB에서 조회하는 로직을 중점적으로 리뷰 부탁드립니다.
*   리팩토링 작업이 기존의 '이어쓰기 제안' 기능에 사이드 이펙트를 일으키지 않았는지 테스트 시나리오를 통해 함께 검증해주시면 감사하겠습니다.

---

## 셀프 체크리스트 (Self-Checklist)

*   [x] 제목 규칙을 지켰습니다.
*   [x] 관련 이슈를 연결했습니다.
*   [x] 로컬에서 DB 초기화 후 Postman E2E 테스트(회원가입~이어쓰기)를 성공적으로 완료했습니다.
*   [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.

---

## 리뷰어에게 (To Reviewers)

*   이번 리팩토링의 핵심은 `Genres` 엔티티의 `name` 필드를 `Enum`으로 변경하여 타입 안정성을 확보한 것입니다.
*   **테스트를 진행하시기 전에, 반드시 `테스트 방법` 섹션의 DB 초기화 및 데이터 재입력 스크립트를 실행해주셔야 합니다.**
*   `NovelServiceTj`에서 클라이언트로부터 받은 `List<String>`을 `List<Genres.GenreType>`으로 변환하고, 이를 다시 DB에서 조회하는 로직을 중점적으로 리뷰 부탁드립니다.
*   리팩토링 작업이 기존의 '이어쓰기 제안' 기능에 사이드 이펙트를 일으키지 않았는지 테스트 시나리오를 통해 함께 검증해주시면 감사하겠습니다.